### PR TITLE
remove BGR2RGB change results is more accurate age for age_googlenet.onnx

### DIFF
--- a/src/age_and_gender_detection/age_and_gender_detection/model.py
+++ b/src/age_and_gender_detection/age_and_gender_detection/model.py
@@ -104,7 +104,7 @@ class AgeGenderDetector:
         return boxes, labels, probs
 
     def genderClassifier(self, orig_image):
-        image = cv2.cvtColor(orig_image, cv2.COLOR_BGR2RGB)
+        image = orig_image.copy()
         image = cv2.resize(image, (224, 224))
         image_mean = np.array([104, 117, 123])
         image = image - image_mean
@@ -118,7 +118,7 @@ class AgeGenderDetector:
         return gender
 
     def ageClassifier(self, orig_image):
-        image = cv2.cvtColor(orig_image, cv2.COLOR_BGR2RGB)
+        image = orig_image.copy()
         image = cv2.resize(image, (224, 224))
         image_mean = np.array([104, 117, 123])
         image = image - image_mean


### PR DESCRIPTION
current code results in accurate age detect .  as per ai original GoogLeNet model, particularly the popular bvlc_googlenet.caffemodel (and thus many age_googlenet.onnx models derived from it), was perhaps trained with BGR images. hence remove COLOR_BGR2RGB results in more accurate age